### PR TITLE
Refactor receipt form field visibility and swap item/share sections

### DIFF
--- a/lib/receipts/widgets/receipt_form.dart
+++ b/lib/receipts/widgets/receipt_form.dart
@@ -229,33 +229,45 @@ class _ReceiptForm extends State<ReceiptForm> {
   Widget buildCategoryField() {
     var initialCategories = modifiedReceipt.categories?.toList() ?? [];
 
-    return CategorySelectField(
-      fieldName: "categories",
-      label: "Categories",
-      initialCategories: initialCategories,
-      formState: formState,
-      onCategoriesChanged: (categories) => {
-        setState(() {
-          widget.formKey.currentState?.fields["categories"]
-              ?.setValue(categories);
-        }),
-      },
+    return Visibility(
+      visible: groupModel
+              .getGroupReceiptSettings(groupId)
+              ?.hideReceiptCategories ==
+          false,
+      child: CategorySelectField(
+        fieldName: "categories",
+        label: "Categories",
+        initialCategories: initialCategories,
+        formState: formState,
+        onCategoriesChanged: (categories) => {
+          setState(() {
+            widget.formKey.currentState?.fields["categories"]
+                ?.setValue(categories);
+          }),
+        },
+      ),
     );
   }
 
   Widget buildTagField() {
     var initialTags = modifiedReceipt.tags?.toList() ?? [];
 
-    return TagSelectField(
-        label: "Tags",
-        fieldName: "tags",
-        initialTags: initialTags,
-        formState: formState,
-        onTagsChanged: (tags) => {
-              setState(() {
-                widget.formKey.currentState?.fields["tags"]?.setValue(tags);
-              })
-            });
+    return Visibility(
+      visible: groupModel
+              .getGroupReceiptSettings(groupId)
+              ?.hideReceiptTags ==
+          false,
+      child: TagSelectField(
+          label: "Tags",
+          fieldName: "tags",
+          initialTags: initialTags,
+          formState: formState,
+          onTagsChanged: (tags) => {
+                setState(() {
+                  widget.formKey.currentState?.fields["tags"]?.setValue(tags);
+                })
+              }),
+    );
   }
 
   Widget buildCustomFieldsSection() {
@@ -721,24 +733,10 @@ class _ReceiptForm extends State<ReceiptForm> {
             textFieldSpacing,
             buildCustomFieldsSection(),
             textFieldSpacing,
-            Visibility(
-                visible: groupModel
-                        .getGroupReceiptSettings(groupId)
-                        ?.hideReceiptCategories ==
-                    false,
-                child: Column(children: [
-                  buildCategoryField(),
-                  textFieldSpacing,
-                ])),
-            Visibility(
-                visible: groupModel
-                        .getGroupReceiptSettings(groupId)
-                        ?.hideReceiptTags ==
-                    false,
-                child: Column(children: [
-                  buildTagField(),
-                  textFieldSpacing,
-                ])),
+            buildCategoryField(),
+            textFieldSpacing,
+            buildTagField(),
+            textFieldSpacing,
             buildSharesSection(),
             textFieldSpacing,
             ReceiptShareField(

--- a/lib/receipts/widgets/receipt_form.dart
+++ b/lib/receipts/widgets/receipt_form.dart
@@ -120,13 +120,14 @@ class _ReceiptForm extends State<ReceiptForm> {
           label: "Amount",
           fieldName: "amount",
           initialAmount: receiptModel.modifiedReceipt.amount.toString(),
-          formState: receiptModel.syncWithItems ? WranglerFormState.view : formState,
-          decoration: receiptModel.syncWithItems 
-            ? const InputDecoration(
-                labelText: "Amount",
-                helperText: "Calculated from items total",
-              )
-            : null,
+          formState:
+              receiptModel.syncWithItems ? WranglerFormState.view : formState,
+          decoration: receiptModel.syncWithItems
+              ? const InputDecoration(
+                  labelText: "Amount",
+                  helperText: "Calculated from items total",
+                )
+              : null,
         );
       },
     );
@@ -230,10 +231,9 @@ class _ReceiptForm extends State<ReceiptForm> {
     var initialCategories = modifiedReceipt.categories?.toList() ?? [];
 
     return Visibility(
-      visible: groupModel
-              .getGroupReceiptSettings(groupId)
-              ?.hideReceiptCategories ==
-          false,
+      visible:
+          groupModel.getGroupReceiptSettings(groupId)?.hideReceiptCategories ==
+              false,
       child: CategorySelectField(
         fieldName: "categories",
         label: "Categories",
@@ -253,10 +253,8 @@ class _ReceiptForm extends State<ReceiptForm> {
     var initialTags = modifiedReceipt.tags?.toList() ?? [];
 
     return Visibility(
-      visible: groupModel
-              .getGroupReceiptSettings(groupId)
-              ?.hideReceiptTags ==
-          false,
+      visible:
+          groupModel.getGroupReceiptSettings(groupId)?.hideReceiptTags == false,
       child: TagSelectField(
           label: "Tags",
           fieldName: "tags",
@@ -563,9 +561,7 @@ class _ReceiptForm extends State<ReceiptForm> {
                       _showQuickAddShare ? Icons.remove : Icons.add,
                       color: Theme.of(context).primaryColor,
                     ),
-                    tooltip: _showQuickAddShare
-                        ? "Hide Add"
-                        : "Add Share",
+                    tooltip: _showQuickAddShare ? "Hide Add" : "Add Share",
                   ),
                   IconButton(
                     onPressed: () {
@@ -737,16 +733,16 @@ class _ReceiptForm extends State<ReceiptForm> {
             textFieldSpacing,
             buildTagField(),
             textFieldSpacing,
+            buildItemsSection(),
+            textFieldSpacing,
+            buildReceiptItemList(),
+            textFieldSpacing,
             buildSharesSection(),
             textFieldSpacing,
             ReceiptShareField(
               groupId: groupId,
               formKey: widget.formKey,
             ),
-            textFieldSpacing,
-            buildItemsSection(),
-            textFieldSpacing,
-            buildReceiptItemList(),
             textFieldSpacing,
             kDebugMode
                 ? ElevatedButton(


### PR DESCRIPTION
## Changes
1. **Refactored field visibility logic**: The visibility logic for category and tag fields is now encapsulated within their respective builder functions, removing nested Visibility widgets from the main build method
2. **Reordered form sections**: Items section now appears before shares section for better user workflow